### PR TITLE
Allow multiple group names in inviteNewShopMember

### DIFF
--- a/src/startup.js
+++ b/src/startup.js
@@ -7,8 +7,6 @@ import seedEmailTemplatesForShop from "./util/seedEmailTemplatesForShop.js";
  * @returns {undefined}
  */
 export default async function emailTemplatesStartup(context) {
-  await seedEmailTemplatesForShop(context, "CegM7hSbdShjomCsD");
-
   context.appEvents.on("afterShopCreate", async (payload) => {
     const { shop } = payload;
 

--- a/src/startup.js
+++ b/src/startup.js
@@ -7,6 +7,8 @@ import seedEmailTemplatesForShop from "./util/seedEmailTemplatesForShop.js";
  * @returns {undefined}
  */
 export default async function emailTemplatesStartup(context) {
+  await seedEmailTemplatesForShop(context, "CegM7hSbdShjomCsD");
+
   context.appEvents.on("afterShopCreate", async (payload) => {
     const { shop } = payload;
 

--- a/src/templates/accounts/inviteNewShopMember.js
+++ b/src/templates/accounts/inviteNewShopMember.js
@@ -69,7 +69,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                     <td height="20" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-family: 'Lato', sans-serif; font-size:13px; font-weight:bold; line-height:18px; color:#4d4d4d; letter-spacing: -0.5px;"><span style="font-weight:bold;">{{currentUserName}}</span> from {{shopName}} has invited you to join the group {{groupName}}.</td>
+                    <td align="left" valign="top" style="font-family: 'Lato', sans-serif; font-size:13px; font-weight:bold; line-height:18px; color:#4d4d4d; letter-spacing: -0.5px;"><span style="font-weight:bold;">{{currentUserName}}</span> from {{shopName}} has invited you to join the groups {{groupNames}}.</td>
                   </tr>
                   <tr>
                     <td height="25" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>

--- a/src/templates/accounts/inviteNewShopMember.js
+++ b/src/templates/accounts/inviteNewShopMember.js
@@ -69,7 +69,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                     <td height="20" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-family: 'Lato', sans-serif; font-size:13px; font-weight:bold; line-height:18px; color:#4d4d4d; letter-spacing: -0.5px;"><span style="font-weight:bold;">{{currentUserName}}</span> from {{shopName}} has invited you to join the groups {{groupNames}}.</td>
+                    <td align="left" valign="top" style="font-family: 'Lato', sans-serif; font-size:13px; font-weight:bold; line-height:18px; color:#4d4d4d; letter-spacing: -0.5px;"><span style="font-weight:bold;">{{currentUserName}}</span> from {{shopName}} has invited you to join the group{{#if hasMultipleGroups}}s{{/if}} {{groupNames}}.</td>
                   </tr>
                   <tr>
                     <td height="25" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
@@ -95,7 +95,7 @@ table[class=wrap1001], td[class=wrap1001] { width:96% !important; margin:0 !impo
                     <td height="15" align="left" valign="top" style="font-size:1px; line-height:1px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:17px;">You received this email because you were invited to join a group in the store {{shopName}}. Questions or suggestions? Email us at <a href="mailto:{{contactEmail}}" style="text-decoration:none; color:#1e98d5;">{{contactEmail}}</a></td>
+                    <td align="left" valign="top" style="font-family:Arial, Helvetica, sans-serif; font-size:12px; font-weight:normal; line-height:17px;">You received this email because you were invited to join {{#if hasMultipleGroups}}groups{{else}}a group{{/if}} in the store {{shopName}}. Questions or suggestions? Email us at <a href="mailto:{{contactEmail}}" style="text-decoration:none; color:#1e98d5;">{{contactEmail}}</a></td>
                   </tr>
                   <!-- Begin Social Icons -->
                   {{#if socialLinks.display}}

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -35,7 +35,7 @@ export default [
     title: "Accounts - Invite Shop Member - New User Account",
     name: "accounts/inviteNewShopMember",
     template: inviteNewShopMemberTemplate,
-    subject: "You have been invited to join groups {{groupNames}} in the store \"{{shop.name}}\""
+    subject: "You have been invited to join group{{#if hasMultipleGroups}}s{{/if}} {{groupNames}} in the store \"{{shop.name}}\""
   },
 
   /*

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -35,7 +35,7 @@ export default [
     title: "Accounts - Invite Shop Member - New User Account",
     name: "accounts/inviteNewShopMember",
     template: inviteNewShopMemberTemplate,
-    subject: "You have been invited to join the group \"{{groupName}}\" in the store \"{{shop.name}}\""
+    subject: "You have been invited to join groups {{groupNames}} in the store \"{{shop.name}}\""
   },
 
   /*


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #5
Impact: **breaking**
Type: **feature**

## Issue
The `inviteNewShopMember` template is written to only allow one group name.

## Solution
Adapt the template to allow multiple group names.

## Breaking changes
`groupName` becomes `groupNames`, and is expected to still be a string. The string should be pre-formatted as coma-delimitated group names, readable by a human. There's also a new `hasMultipleGroups` boolean variable. Setting it to true will trigger the plural form.


## Testing
1. Send an e-mail with `groupNames: "some-group and some-other-group", and `hasMultipleGroups: true`.
2. Validate that the plural form is used, with the groups showing in the subject and body.
3. Send an e-mail with `groupNames: "some-group"` and `hasMultipleGroups: false`.
4. Validate that the singular form is used, with the single group name showing in the subject and body.