### PR TITLE
Update email templates at startup

### DIFF
--- a/src/startup.js
+++ b/src/startup.js
@@ -7,6 +7,11 @@ import seedEmailTemplatesForShop from "./util/seedEmailTemplatesForShop.js";
  * @returns {undefined}
  */
 export default async function emailTemplatesStartup(context) {
+  context.appEvents.on("afterShopCreate", async (payload) => {
+    const { shop } = payload;
+
+    await seedEmailTemplatesForShop(context, shop._id);
+  });
   // Update templates if they don't already exist.
   const primaryShopId = await context.queries.primaryShopId(context.getInternalContext());
   if(primaryShopId) {

--- a/src/startup.js
+++ b/src/startup.js
@@ -7,9 +7,9 @@ import seedEmailTemplatesForShop from "./util/seedEmailTemplatesForShop.js";
  * @returns {undefined}
  */
 export default async function emailTemplatesStartup(context) {
-  context.appEvents.on("afterShopCreate", async (payload) => {
-    const { shop } = payload;
-
-    await seedEmailTemplatesForShop(context, shop._id);
-  });
+  // Update templates if they don't already exist.
+  const primaryShopId = await context.queries.primaryShopId(context.getInternalContext());
+  if(primaryShopId) {
+    await seedEmailTemplatesForShop(context, primaryShopId);
+  }
 }

--- a/src/startup.js
+++ b/src/startup.js
@@ -14,7 +14,7 @@ export default async function emailTemplatesStartup(context) {
   });
   // Update templates if they don't already exist.
   const primaryShopId = await context.queries.primaryShopId(context.getInternalContext());
-  if(primaryShopId) {
+  if (primaryShopId) {
     await seedEmailTemplatesForShop(context, primaryShopId);
   }
 }


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
Currently, if we upgrade templates version or add new templates, they are not registered because templates are registered only at _shopCreate_ event.

## Solution
With this change, any new updates will be picked up.