### PR TITLE
Bugfix/edges

### DIFF
--- a/src/resolvers/Template/index.js
+++ b/src/resolvers/Template/index.js
@@ -1,6 +1,0 @@
-import { encodeShopOpaqueId, encodeTemplateOpaqueId } from "../../xforms/id.js";
-
-export default {
-  _id: (node) => encodeTemplateOpaqueId(node._id),
-  shopId: (node) => encodeShopOpaqueId(node.shopId)
-};

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,11 +1,9 @@
 import getConnectionTypeResolvers from "@reactioncommerce/api-utils/graphql/getConnectionTypeResolvers.js";
 import Query from "./Query/index.js";
 import Mutation from "./Mutation/index.js";
-import Template from "./Template/index.js";
 
 export default {
-  ...getConnectionTypeResolvers(Template),
   Query,
   Mutation,
-  Template
+  ...getConnectionTypeResolvers("Template")
 };

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,8 +1,10 @@
+import getConnectionTypeResolvers from "@reactioncommerce/api-utils/graphql/getConnectionTypeResolvers.js";
 import Query from "./Query/index.js";
 import Mutation from "./Mutation/index.js";
 import Template from "./Template/index.js";
 
 export default {
+  ...getConnectionTypeResolvers(Template),
   Query,
   Mutation,
   Template

--- a/src/startup.js
+++ b/src/startup.js
@@ -12,6 +12,7 @@ export default async function emailTemplatesStartup(context) {
 
     await seedEmailTemplatesForShop(context, shop._id);
   });
+
   // Update templates if they don't already exist.
   const primaryShopId = await context.queries.primaryShopId(context.getInternalContext());
   if (primaryShopId) {


### PR DESCRIPTION
Resolves #9 
Impact: **minor**
Type: **bugfix**

## Issue
`emailTemplates` query does not report edges, only nodes

## Solution
The resolver for template should receive the right schema.

## Testing
```
{
  emailTemplates(shopId:"<shopId>"){
    edges{
      cursor
      node{
        _id
        name
        language
        shopId
        subject
        title
      }
    }
    nodes{
      _id
    }
    totalCount
  }
}
```
1. Run the above query in GraphQL playground. Before pulling the fix it will show "null" for edges. With the fix you should be able to see all values for an edge.

![image](https://user-images.githubusercontent.com/75854210/133664559-e0161578-389b-4a4f-a2dc-de50c7f60a6c.png)

